### PR TITLE
Unify width in inplace buttons

### DIFF
--- a/app/assets/stylesheets/content/_in_place_editing.sass
+++ b/app/assets/stylesheets/content/_in_place_editing.sass
@@ -236,7 +236,9 @@ a.inplace-editing--trigger-link,
   height: 1.5rem
   line-height: 1.5rem
   display: inline-block
-  font-size: 0.95rem
+  font-size: 0.9rem
+
+
 
   a
     color: $body-font-color
@@ -247,7 +249,7 @@ a.inplace-editing--trigger-link,
       border: 1px solid $inplace-edit--border-color
       border-radius: 2px
 
-    .icon-context::before
+    .icon-context:before
       padding: 0
 
 // custom hack to have the jsToolbar in the same line as the "Description" title

--- a/frontend/app/templates/work_packages/inplace_editor/edit_pane.html
+++ b/frontend/app/templates/work_packages/inplace_editor/edit_pane.html
@@ -9,9 +9,8 @@
           </icon-wrapper>
         </accessible-by-keyboard>
         <accessible-by-keyboard execute="editPaneController.submit(true)" class="inplace-edit--control -icons-2 inplace-edit--control--send">
-            <span title="{{ editPaneController.saveAndSendTitle }}">
-              <i class="icon-send-mail"></i>
-            </span>
+            <icon-wrapper icon-name="send-mail" icon-title="{{ editPaneController.saveAndSendTitle }}">
+            </icon-wrapper>
         </accessible-by-keyboard>
         <accessible-by-keyboard execute="editPaneController.discardEditing()" class="inplace-edit--control inplace-edit--control--cancel">
           <icon-wrapper icon-name="close" icon-title="{{ editPaneController.cancelTitle }}">


### PR DESCRIPTION
This unifies the width of the inplace control buttons by using the same DOM-strucutre everywhere. Further for FF and IE I had to take care that the icons won't get too wide when they get a border on hover.
